### PR TITLE
Update Casper.prototype.clear()

### DIFF
--- a/modules/casper.js
+++ b/modules/casper.js
@@ -448,6 +448,7 @@ Casper.prototype.checkStarted = function checkStarted() {
  */
 Casper.prototype.clear = function clear() {
     "use strict";
+    this.page = this.mainPage;
     this.checkStarted();
     this.page.content = '';
     return this;


### PR DESCRIPTION
Update this function to be functional after a selectPopUp().
If after a selectPopUp(), there is an error in the test, there will be no blockage for the rest of the next tests
